### PR TITLE
fix style warning

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -27,7 +27,7 @@ var Select2Component = Ember.Component.extend({
   classNames: ["form-control"],
   classNameBindings: ["inputSize"],
   attributeBindings: ["style"],
-  style: "display: hidden;",
+  style: Ember.String.htmlSafe("display: hidden;"),
 
   // Bindings that may be overwritten in the template
   inputSize: "input-md",


### PR DESCRIPTION
This will fix these warnings:
```
WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see http://emberjs.com/deprecations/v1.x/#toc_warning-when-binding-style-attributes.
```